### PR TITLE
Bug fixes for hrapp and acc deploy

### DIFF
--- a/common/const/doNotRetryErrorCodes.json
+++ b/common/const/doNotRetryErrorCodes.json
@@ -12,10 +12,6 @@
         {
             "code": "ReferencedResourceNotProvisioned",
             "errorDescription": "Cannot proceed with operation because the resource is not in Succeeded state."
-        },
-        {
-            "code": "UserNotAuthorized",
-            "errorDescription": "User is not authorized to create a particular resource/subscription"
         }
     ]
 }


### PR DESCRIPTION
Fixing 2 issues:
 
1. During infra deployment, the key management permissions are not applied instantly making some future operations fail with an invalid permission error. This results in many failed deployments as our retry logic won't apply when it gets a permission error. Enabling retries on permission errors.
2. Azure and SQL sessions are required to deploy the sample app. However, for some customers it seems the SQL sessions time out causing further deployment errors. Updated the code to create a valid SQL session when it's needed so the **Add-SqlAzureAuthenticationContext** setup step is not strictly needed anymore. 