### PR TITLE
Adding PK to the employee ID column and changing hosting location.

### DIFF
--- a/sovereignApplications/confidential/contosoHR/config/cloud-init.yaml
+++ b/sovereignApplications/confidential/contosoHR/config/cloud-init.yaml
@@ -26,7 +26,7 @@ write_files:
     [Install]
     WantedBy=multi-user.target
 runcmd:
-- wget https://hrwebapp.blob.core.windows.net/contosohr/ContosoHR.zip
+- wget https://customerprototypes.blob.core.windows.net/contosohr/ContosoHR.zip
 - mkdir --parents /home/contosohr/ContosoHR
 - bsdtar --extract --file ContosoHR.zip --directory /home/contosohr/ContosoHR --strip-components=1
 - chown --recursive contosohr:contosohr /home/contosohr/

--- a/sovereignApplications/confidential/contosoHR/data/schema.sql
+++ b/sovereignApplications/confidential/contosoHR/data/schema.sql
@@ -3,7 +3,7 @@
 --- SUMMARY: Create employee table ---
 CREATE TABLE [HR].[Employees]
 (
-    [EmployeeID] [int] IDENTITY(1,1) NOT NULL,
+    [EmployeeID] [int] IDENTITY(1,1) PRIMARY KEY NOT NULL,
     [SSN] [char](11) NOT NULL,
     [FirstName] [nvarchar](50) NOT NULL,
     [LastName] [nvarchar](50) NOT NULL,


### PR DESCRIPTION
The employee ID column needs a PK for encryption and moving the hosting of the artifacts to our standard storage account.